### PR TITLE
fix: pin postgres to 17 to avoid 18+ data layout breakage

### DIFF
--- a/services/postgres/service.yml
+++ b/services/postgres/service.yml
@@ -2,7 +2,10 @@ version: '3.8'
 
 services:
   postgres:
-    image: postgres:latest
+    # Pinned to 17 because 18+ changed the data directory layout (mount must be
+    # /var/lib/postgresql, not /var/lib/postgresql/data). Bumping to 18 requires
+    # a pg_upgrade of existing POSTGRES_HOME data.
+    image: postgres:17
     environment:
       POSTGRES_USER: test
       POSTGRES_PASSWORD: test


### PR DESCRIPTION
## Summary
- Pin `postgres:latest` to `postgres:17` in `services/postgres/service.yml`
- Postgres 18+ changed the volume layout (mount must be `/var/lib/postgresql`, not `/var/lib/postgresql/data`), which breaks the existing `${POSTGRES_HOME}` data and causes the container to refuse to start
- Pinning keeps existing dev data working without a `pg_upgrade` migration

## Future migration to 18+
If we want to bump later, two changes are required together:
1. Change the mount in `services/postgres/service.yml` from `:/var/lib/postgresql/data` to `:/var/lib/postgresql`
2. Migrate the existing `${POSTGRES_HOME}` data via `pg_upgrade --link` (see https://github.com/docker-library/postgres/issues/37) — or wipe `${POSTGRES_HOME}` for a fresh init if dev data is disposable

## Test plan
- [x] `docker-compose up -d --force-recreate postgres` starts cleanly with the pinned image
- [x] `docker ps` shows `postgres:17` running and healthy
- [ ] Verify connection with existing tooling against `localhost:5432` (`test`/`test`/`testdb`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)